### PR TITLE
fix: support Angular 22 peer dependencies

### DIFF
--- a/projects/schedule-x/angular/package.json
+++ b/projects/schedule-x/angular/package.json
@@ -15,8 +15,8 @@
   },
   "version": "4.0.0",
   "peerDependencies": {
-    "@angular/common": "14 - 21",
-    "@angular/core": "14 - 21",
+    "@angular/common": "14 - 22",
+    "@angular/core": "14 - 22",
     "@schedule-x/calendar": "^4.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
Schedulix Angular can now be installed in Angular 22 projects without tripping the package's peer dependency cap. The Angular `common` and `core` peer ranges now include 22 while preserving support for Angular 14 through 21.

Tested with `npm run build:lib`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
